### PR TITLE
Fix to deduping of multiple feeds

### DIFF
--- a/lib/Plagger/Plugin/Filter/Rule.pm
+++ b/lib/Plagger/Plugin/Filter/Rule.pm
@@ -24,8 +24,6 @@ sub feed {
             unless $self->{entries}->{$entry};
     }
 
-    $self->{entries} = {};
-
     if ($args->{feed}->count == 0) {
         $context->log(debug => "Deleting " . $args->{feed}->title . " since it has 0 entries");
         $context->update->delete_feed($args->{feed})

--- a/lib/Plagger/Plugin/Namespace/MediaRSS.pm
+++ b/lib/Plagger/Plugin/Namespace/MediaRSS.pm
@@ -26,7 +26,9 @@ sub handle {
             $args->{entry}->add_enclosure($enclosure);
         }
 
-        if (my $thumbnail = $media->{$media_ns}->{thumbnail}) {
+        my $thumbnail = $media->{$media_ns}->{thumbnail};
+        $thumbnail = $thumbnail->[0] if (ref($thumbnail) eq "ARRAY");
+        if ($thumbnail) {
             $args->{entry}->icon({
                 url   => $thumbnail->{url},
                 width => $thumbnail->{width},


### PR DESCRIPTION
Hi,

I've been using Plagger for years, and during that time I've made lots of changes and added new plugins and so on.  I would have contributed these back earlier, but the subversion repository disappeared and I assumed the project was dead.  Turns out, not quite.  So I guess I'll try to slowly separate my changes and suggest them one at a time.

Here's the first, which fixes a problem I had with deduping.  The deduping gets called once per entry to figure out if it should be removed, in which case it removes the entry from its list.  Then it gets called once per feed, where it goes through and removes all entries that don't appear in the list.  At the end of this second pass it erases the list of valid entries entirely.  This means that subsequent feeds get _all_ their entries removed, and only one feed ever gets published.

So I simply removed the clearing out of the list.  It seems to work as intended.  Please let me know if there was some good reason for it to clear out the list.
