### PR TITLE
Filter::Regexp now works on each entry as intended

### DIFF
--- a/lib/Plagger/Plugin/Filter/Regexp.pm
+++ b/lib/Plagger/Plugin/Filter/Regexp.pm
@@ -17,7 +17,7 @@ sub filter {
     my($self, $body) = @_;
 
     local $_ = $body;
-    my $regexp = decode_utf8($self->conf->{regexp}, Encode::FB_CROAK);
+    my $regexp = decode_utf8($self->conf->{regexp}, Encode::FB_CROAK | Encode::LEAVE_SRC);
     my $count = eval $regexp;
 
     if ($@) {

--- a/t/plugins/Filter-Regexp/base.t
+++ b/t/plugins/Filter-Regexp/base.t
@@ -15,9 +15,12 @@ plugins:
       entry:
         - title: bar
           body: Plagger
+        - title: baz
+          body: Plagger, she said.
   - module: Filter::Regexp
     config:
       regexp: s/Plagger/Plagger is a pluggable aggregator/g
       text_only: 1
 --- expected
-is $context->update->feeds->[0]->entries->[0]->body, "Plagger is a pluggable aggregator"
+is $context->update->feeds->[0]->entries->[0]->body, "Plagger is a pluggable aggregator";
+is $context->update->feeds->[0]->entries->[1]->body, "Plagger is a pluggable aggregator, she said.";


### PR DESCRIPTION
Encode::decode overwrites the source string when FB_CROAK is used as the
CHECK flag.  This sets the 'regex' config value to an empty string after
processing the first entry, which means the regex never runs on
subsequent entries.  Adding LEAVE_SRC to the CHECK flag ensures the
plugin's config data isn't touched.
