### PR TITLE
added Module::Install::TestBase

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -49,6 +49,7 @@ include_deps('YAML');
 
 build_requires('Test::More', 0.42);
 build_requires('Test::Base', 0.52);
+build_requires('Module::Install::TestBase');
 
 features(
     'Better Encoding detection' => [


### PR DESCRIPTION
最近、Test::BaseからModule::Install::TestBaseが切りだされ、インストールが出来なくなったので、Makefile.PLに追加しておきました。
